### PR TITLE
Fix for crash when setting application base

### DIFF
--- a/src/editor/PropertyEditor/PropertyPresenter.cs
+++ b/src/editor/PropertyEditor/PropertyPresenter.cs
@@ -127,9 +127,13 @@ namespace NUnit.ProjectEditor
 
         private void BrowseConfigBaseCommand_Execute()
         {
+            string config = "unset";
+            if (_view.ConfigList.SelectedIndex >= 0)
+                config = _model.Configs[_view.ConfigList.SelectedIndex].Name;
+
             string message = string.Format(
                 "Select ApplicationBase for the {0} configuration, if different from the model as a whole.",
-                _model.Configs[_view.ConfigList.SelectedIndex].Name);
+                config);
             string initialFolder = _view.ApplicationBase.Text;
             if (initialFolder == string.Empty)
                 initialFolder = _view.ProjectBase.Text;


### PR DESCRIPTION
Fixes #15 

This is happening because no configs have been created yet so the selected index in the following code is -1 and then the node we are getting the name for is null. `_model.Configs[_view.ConfigList.SelectedIndex].Name`

Easy fix is to prevent the error which I did. This doesn't address the issue that anything that you set in the lower area is lost as soon as you create a configuration. I just wanted to get the crash itself fixed, we can address the usability if this project gets more usage.