### PR TITLE
Update package references

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -118,16 +118,6 @@ Task("Test")
 // PACKAGE
 //////////////////////////////////////////////////////////////////////
 
-Task("PackageSource")
-.Does(() =>
-{
-    var path = PACKAGE_DIR + "NUnit-Project-Editor-" + packageVersion + "-src.zip";
-
-    CreateDirectory(PACKAGE_DIR);
-    
-    RunGitCommand(string.Format("archive -o {0} HEAD", path));
-});
-
 Task("PackageZip")
 .Does(() =>
 {
@@ -170,7 +160,6 @@ Task("Rebuild")
 .IsDependentOn("Build");
 
 Task("Package")
-.IsDependentOn("PackageSource")
 .IsDependentOn("PackageZip");
 
 Task("Appveyor")

--- a/build.cake
+++ b/build.cake
@@ -85,6 +85,7 @@ Task("Build")
         MSBuild(SOLUTION, new MSBuildSettings()
             .SetConfiguration(configuration)
             .SetVerbosity(Verbosity.Minimal)
+			.SetPlatformTarget(PlatformTarget.MSIL)
             .SetNodeReuse(false));
     }
     else

--- a/src/tests/nunit-editor.tests.csproj
+++ b/src/tests/nunit-editor.tests.csproj
@@ -57,8 +57,8 @@
       <HintPath>..\..\packages\NSubstitute.1.10.0.0\lib\net35\NSubstitute.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.3.2.1\lib\net35\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.5.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\NUnit.3.5.0\lib\net35\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/tests/packages.config
+++ b/src/tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NSubstitute" version="1.10.0.0" targetFramework="net35" />
-  <package id="NUnit" version="3.2.1" targetFramework="net35" />
+  <package id="NUnit" version="3.5.0" targetFramework="net35" />
 </packages>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-    <package id="Cake" version="0.6.4" />
-    <package id="NUnit.ConsoleRunner" version="3.2.1" />
+    <package id="Cake" version="0.17" />
+    <package id="NUnit.ConsoleRunner" version="3.5" />
 </packages>


### PR DESCRIPTION
Fixes #22

Updated as follows:
Cake 0.17.0
NUnit 3.5.0
NUnit.ConsoleRunner 3.5.0

Also dropped source packaging from the build script.