### PR TITLE
Create chocolatey package as a part of the build

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -139,6 +139,25 @@ Task("PackageZip")
     Zip(BIN_DIR, File(path), zipFiles);
 });
 
+Task("PackageChocolatey")
+.Does(() =>
+{
+	CreateDirectory("PACKAGE_DIR");
+
+	ChocolateyPack("nunit-project-editor.nuspec", 
+		new ChocolateyPackSettings()
+		{
+			OutputDirectory = PACKAGE_DIR,
+			Files = new []
+			{
+				new ChocolateyNuSpecContent { Source = "LICENSE.txt" },
+				new ChocolateyNuSpecContent { Source = "CHANGES.txt" },
+				new ChocolateyNuSpecContent { Source = BIN_DIR + "nunit-editor.exe", Target = "bin" },
+				new ChocolateyNuSpecContent { Source = BIN_DIR + "nunit.ico", Target = "bin" }
+			}
+		});
+}); 
+
 //////////////////////////////////////////////////////////////////////
 // HELPER METHODS
 //////////////////////////////////////////////////////////////////////
@@ -160,7 +179,8 @@ Task("Rebuild")
 .IsDependentOn("Build");
 
 Task("Package")
-.IsDependentOn("PackageZip");
+.IsDependentOn("PackageZip")
+.IsDependentOn("PackageChocolatey");
 
 Task("Appveyor")
 .IsDependentOn("Build")

--- a/build.cake
+++ b/build.cake
@@ -121,7 +121,7 @@ Task("Test")
 Task("PackageZip")
 .Does(() =>
 {
-    var path = PACKAGE_DIR + "NUnit-Project-Editor-" + packageVersion + dbgSuffix + ".zip";
+    var path = PACKAGE_DIR + "nunit-project-editor-" + packageVersion + dbgSuffix + ".zip";
 
     CreateDirectory(PACKAGE_DIR);
 

--- a/nunit-editor.sln
+++ b/nunit-editor.sln
@@ -1,9 +1,17 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 11.00
-# Visual Studio 2010
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nunit-editor", "src\editor\nunit-editor.csproj", "{ED57DCEC-3C16-4A90-BD3C-4D5BE5AD70FB}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "nunit-editor.tests", "src\tests\nunit-editor.tests.csproj", "{A9E1C1E9-AE97-4510-AD94-EAFADE425FBE}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B391C3C8-08C3-4638-A1BC-9FE5C094D9F9}"
+	ProjectSection(SolutionItems) = preProject
+		build.cake = build.cake
+		nunit-project-editor.nuspec = nunit-project-editor.nuspec
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/nunit-project-editor.nuspec
+++ b/nunit-project-editor.nuspec
@@ -1,0 +1,28 @@
+﻿<!-- Do not remove this test for UTF-8: if “Ω” doesn’t appear as greek uppercase omega letter enclosed in quotation marks, you should use an editor that supports UTF-8, not this one. -->
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>nunit-project-editor</id>
+    <version>1.0</version>
+    <packageSourceUrl>https://github.com/nunit/nunit-project-editor/chocolatey/</packageSourceUrl>
+    <owners>Charlie Poole</owners>
+
+    <title>NUnit Project Editor</title>
+    <authors>Charlie Poole</authors>
+    <!-- projectUrl is required for the community feed -->
+    <projectUrl>https://github.com/nunit/nunit-project-editor</projectUrl>
+    <iconUrl>http://cdn.rawgit.com/nunit/resources/master/images/icon/nunit_64.png</iconUrl>
+    <copyright>2016 Charlie Poole</copyright>
+    <licenseUrl>http://github.com/nunit/nunit-project-editor/LICENSE.txt</licenseUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectSourceUrl>https://github.com/nunit/nunit-project-editor</projectSourceUrl>
+    <docsUrl>https://github.com/nunit/docs/wiki/Project-Editor</docsUrl>
+    <tags>nunit project editor unit testing</tags>
+    <summary>Editor for NUnit Test Projects</summary>
+    <description>NUnit supports NUnit projects (extension .nunit) to define a collection of test assemblies that are loaded and run together. This tool is used to edit the contents of an NUnit Test Project.</description>
+    <releaseNotes>This is the first independent production release of the editor, which was previously bundled with NUnit V2.</releaseNotes>
+
+    <!--<provides>NOT YET IMPLEMENTED</provides>-->
+    <!--<conflicts>NOT YET IMPLEMENTED</conflicts>-->
+    <!--<replaces>NOT YET IMPLEMENTED</replaces>-->
+  </metadata>
+</package>


### PR DESCRIPTION
Fixes #21 

I tested the install and uninstall of the package locally. One problem with initial development is that there seems to be no way to see how it will look in the chocolatey.org site once uploaded. This is of course a common problem to nuget.org and the vs gallery as well so I guess we will get around it.

@FerventCoder I'd appreciate your taking a look at this along with any @nunit/core-team members.